### PR TITLE
Add Schwab brokerage support and update gamma analysis utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Real-Time Gamma Exposure Plotter
 
-This repository contains the Python code for a real-time gamma exposure plotting tool designed for options trading. The tool visualizes gamma exposure per strike, changes in gamma exposure, and total gamma exposure over time, integrating live market data to provide insightful visual analytics.
+This repository contains the Python code for a real-time gamma exposure plotting tool designed for options trading. The tool visualizes gamma exposure per strike, changes in gamma exposure, and total gamma exposure over time, integrating live market data to provide insightful visual analytics.  The application now supports both TD Ameritrade and Charles Schwab brokerage APIs.
 
 ## Overview
 
@@ -10,6 +10,14 @@ The `RealTimeGammaPlotter` class is a comprehensive tool that handles real-time 
 - Total gamma exposure alongside SPX spot prices over time.
 
 It is equipped with a deque data structure to manage real-time changes efficiently and matplotlib for dynamic plotting.
+
+### Broker configuration
+
+The data ingestion layer automatically selects a brokerage API based on what is
+available in your environment.  Set the ``BROKER`` environment variable to
+``schwab`` or ``tda`` to explicitly choose a provider.  Each broker requires a
+``secretsSchwab.py`` or ``secretsTDA.py`` module (respectively) that exposes the
+credentials referenced in ``main.py``.
 
 ## Features
 
@@ -71,6 +79,7 @@ selenium==4.18.1
 six==1.16.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
+schwab-py==1.0.0
 tda-api==1.6.0
 trio==0.24.0
 trio-websocket==0.11.1

--- a/gamma_analysis.py
+++ b/gamma_analysis.py
@@ -1,52 +1,89 @@
-import datetime
+"""Utilities for calculating gamma exposure metrics."""
 
-def calculate_gamma_exposure(data, previous_gamma_exposure=None):
-    per_strike_gamma_exposure = {}
-    change_in_gamma_per_strike = {}
-    time_of_change_per_strike = {}
-    total_gamma_exposure = 0
+import datetime
+from typing import Dict, Tuple, List, Optional
+
+
+GammaCalculationResult = Tuple[
+    float,
+    Dict[float, float],
+    Dict[float, float],
+    List[Tuple[float, float, str]],
+    float,
+]
+
+
+def calculate_gamma_exposure(
+    data: Dict,
+    previous_gamma_exposure: Optional[Dict[float, float]] = None,
+) -> GammaCalculationResult:
+    """Compute gamma exposure statistics for the provided option chain data."""
+
+    previous_gamma_exposure = previous_gamma_exposure or {}
+    per_strike_gamma_exposure: Dict[float, float] = {}
+    change_in_gamma_per_strike: Dict[float, float] = {}
+    time_of_change_per_strike: Dict[float, datetime.datetime] = {}
     contract_size = 100
-    spot_price = data.get('underlyingPrice', 0)
+    spot_price = data.get("underlyingPrice", 0)
     calculation_time = datetime.datetime.now()
 
-    def add_gamma_exposure(option_type, strike, gamma, volume):
+    def add_gamma_exposure(option_type: str, strike: str, gamma: float, volume: float) -> None:
         try:
-            if option_type == 'call':
-                gamma_exposure = (spot_price * gamma * volume * contract_size * spot_price * 0.01)/1000000000
-            if option_type =='put':
-                gamma_exposure = (-spot_price * gamma * volume * contract_size * spot_price * 0.01)/1000000000
-            strike = float(strike)
-            
-            if strike in per_strike_gamma_exposure:
-                per_strike_gamma_exposure[strike] += gamma_exposure
-            else:
-                per_strike_gamma_exposure[strike] = gamma_exposure
+            multiplier = 1 if option_type == "call" else -1
+            gamma_exposure = (
+                multiplier
+                * spot_price
+                * gamma
+                * volume
+                * contract_size
+                * spot_price
+                * 0.01
+                / 1000000000
+            )
+            strike_value = float(strike)
 
-            # Calculate change in gamma exposure for the strike
-            if strike in previous_gamma_exposure and previous_gamma_exposure[strike] != 0:
-                previous_exposure = previous_gamma_exposure[strike]
-                change = per_strike_gamma_exposure[strike] - previous_exposure
-                change_in_gamma_per_strike[strike] = change
-                time_of_change_per_strike[strike] = calculation_time
+            per_strike_gamma_exposure[strike_value] = (
+                per_strike_gamma_exposure.get(strike_value, 0.0) + gamma_exposure
+            )
 
-        except Exception as e: 
-            print(f"Strike {strike} included incompatible data: {e}")  
-            pass
+            if strike_value in previous_gamma_exposure and previous_gamma_exposure[strike_value] != 0:
+                previous_exposure = previous_gamma_exposure[strike_value]
+                change = per_strike_gamma_exposure[strike_value] - previous_exposure
+                change_in_gamma_per_strike[strike_value] = change
+                time_of_change_per_strike[strike_value] = calculation_time
 
-    for expiration_date, strikes in data.get('callExpDateMap', {}).items():
+        except Exception as exc:  # pragma: no cover - defensive logging
+            print(f"Strike {strike} included incompatible data: {exc}")
+
+    for _, strikes in data.get("callExpDateMap", {}).items():
         for strike, options in strikes.items():
             for option in options:
-                add_gamma_exposure('call', strike, option['gamma'], option['totalVolume'])
+                add_gamma_exposure("call", strike, option["gamma"], option["totalVolume"])
 
-    for expiration_date, strikes in data.get('putExpDateMap', {}).items():
+    for _, strikes in data.get("putExpDateMap", {}).items():
         for strike, options in strikes.items():
             for option in options:
-                add_gamma_exposure('put', strike, option['gamma'], option['totalVolume'])
+                add_gamma_exposure("put", strike, option["gamma"], option["totalVolume"])
 
     total_gamma_exposure = sum(per_strike_gamma_exposure.values())
     print(total_gamma_exposure)
-    largest_changes_with_time = sorted(change_in_gamma_per_strike.items(), key=lambda item: abs(item[1]), reverse=True)[:5]
-    largest_changes = [(strike, change, time_of_change_per_strike[strike].strftime("%Y-%m-%d %H:%M:%S")) for strike, change in largest_changes_with_time]
+    largest_changes_with_time = sorted(
+        change_in_gamma_per_strike.items(), key=lambda item: abs(item[1]), reverse=True
+    )[:5]
+    largest_changes = [
+        (
+            strike,
+            change,
+            time_of_change_per_strike[strike].strftime("%Y-%m-%d %H:%M:%S"),
+        )
+        for strike, change in largest_changes_with_time
+    ]
     print(largest_changes)
 
-    return total_gamma_exposure, per_strike_gamma_exposure, change_in_gamma_per_strike, largest_changes, spot_price
+    return (
+        total_gamma_exposure,
+        per_strike_gamma_exposure,
+        change_in_gamma_per_strike,
+        largest_changes,
+        spot_price,
+    )

--- a/main.py
+++ b/main.py
@@ -1,30 +1,156 @@
+"""Application entry point for streaming gamma exposure analytics.
+
+This module has been updated to support both the legacy TD Ameritrade API and
+the newer Charles Schwab API.  The active broker can be selected with the
+``BROKER`` environment variable (``schwab`` or ``tda``) or automatically falls
+back to the first provider whose configuration is available on the system.
+"""
+
 from datetime import datetime, timedelta
+import inspect
+import os
+from typing import Optional, Tuple, Callable, Dict, Any
+
 import pytz
-from tda import auth, client
-import secretsTDA
-from gamma_analysis import calculate_gamma_exposure
-from plotter import RealTimeGammaPlotter
 import matplotlib.pyplot as plt
 from selenium import webdriver
 import time as time_module
+
+from gamma_analysis import calculate_gamma_exposure
+from plotter import RealTimeGammaPlotter
 from db_storage import store_raw_options_data
 
+
+class BrokerConfigurationError(RuntimeError):
+    """Raised when a supported broker configuration cannot be located."""
+
+
+def _load_broker_client(preferred_broker: Optional[str] = None) -> Tuple[str, object, object, object]:
+    """Locate a supported broker configuration and client.
+
+    Parameters
+    ----------
+    preferred_broker:
+        Optional explicit broker identifier (``"schwab"`` or ``"tda"``).
+
+    Returns
+    -------
+    tuple
+        ``(broker_name, auth_module, client_module, secrets_module)``
+
+    Raises
+    ------
+    BrokerConfigurationError
+        If a usable broker configuration cannot be imported.
+    """
+
+    errors = []
+
+    def try_import(broker_key: str):
+        broker_key = broker_key.lower()
+        if broker_key == "schwab":
+            try:
+                from schwab import auth as schwab_auth, client as schwab_client  # type: ignore
+                import secretsSchwab  # type: ignore
+
+                return "Schwab", schwab_auth, schwab_client, secretsSchwab
+            except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+                errors.append(f"Schwab configuration unavailable: {exc}")
+        elif broker_key == "tda":
+            try:
+                from tda import auth as tda_auth, client as tda_client  # type: ignore
+                import secretsTDA  # type: ignore
+
+                return "TD Ameritrade", tda_auth, tda_client, secretsTDA
+            except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+                errors.append(f"TD Ameritrade configuration unavailable: {exc}")
+
+        return None
+
+    if preferred_broker:
+        broker = try_import(preferred_broker)
+        if broker:
+            return broker
+
+    # Automatic detection order: Schwab first (new platform), then TDA fallback
+    for broker_name in ("schwab", "tda"):
+        broker = try_import(broker_name)
+        if broker:
+            return broker
+
+    raise BrokerConfigurationError(
+        "Unable to locate a usable broker configuration.\n" + "\n".join(errors)
+    )
+
 class GammaExposureScheduler:
-    #initialize and create dictionaries for temporary data storage and analysis
-    def __init__(self):
+    # Initialize and create dictionaries for temporary data storage and analysis
+    def __init__(self, preferred_broker: Optional[str] = None):
         self.current_gamma_exposure = {}
         self.previous_gamma_exposure = {}
         self.change_in_gamma_per_strike = {}
         self.client = None
         self.plotter = RealTimeGammaPlotter()
+        broker_name, self.auth_module, self.client_module, self.secrets = _load_broker_client(
+            preferred_broker or os.environ.get("BROKER")
+        )
+        self.broker_name = broker_name
+        print(f"Using {self.broker_name} broker configuration.")
+
+        # Broker specific defaults
+        self.option_symbol = getattr(self.secrets, "option_symbol", "$SPX.X")
+        self.strike_count = getattr(self.secrets, "strike_count", 50)
+
+    @staticmethod
+    def _filter_supported_kwargs(function: Callable[..., object], raw_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Filter keyword arguments to those supported by ``function``."""
+
+        signature = inspect.signature(function)
+        return {key: value for key, value in raw_kwargs.items() if key in signature.parameters}
 
     #API auth
     def authenticate(self):
         try:
-            self.client = auth.client_from_token_file(secretsTDA.token_path, secretsTDA.api_key)
+            auth_kwargs = {}
+            if hasattr(self.secrets, "redirect_uri"):
+                auth_kwargs["redirect_uri"] = self.secrets.redirect_uri
+            if hasattr(self.secrets, "token_encryption_key"):
+                auth_kwargs["encryption_key"] = getattr(self.secrets, "token_encryption_key")
+            if hasattr(self.secrets, "cert_file"):
+                auth_kwargs["cert_file"] = getattr(self.secrets, "cert_file")
+
+            filtered_kwargs = self._filter_supported_kwargs(
+                self.auth_module.client_from_token_file,
+                auth_kwargs,
+            )
+
+            self.client = self.auth_module.client_from_token_file(
+                self.secrets.token_path,
+                self.secrets.api_key,
+                **filtered_kwargs,
+            )
         except FileNotFoundError:
             with webdriver.Chrome() as driver:
-                self.client = auth.client_from_login_flow(driver, secretsTDA.api_key, secretsTDA.redirect_uri, secretsTDA.token_path)
+                login_kwargs = {
+                    "driver": driver,
+                    "api_key": self.secrets.api_key,
+                    "redirect_uri": getattr(self.secrets, "redirect_uri", None),
+                    "token_path": self.secrets.token_path,
+                }
+
+                # Optional Schwab parameters are passed only if present.
+                for optional_attr in ("cert_file", "encryption_key", "token_encryption_key"):
+                    if hasattr(self.secrets, optional_attr):
+                        login_kwargs[optional_attr] = getattr(self.secrets, optional_attr)
+
+                # Remove keys with None values to avoid unexpected keyword errors
+                login_kwargs = {k: v for k, v in login_kwargs.items() if v is not None}
+
+                filtered_login_kwargs = self._filter_supported_kwargs(
+                    self.auth_module.client_from_login_flow,
+                    login_kwargs,
+                )
+
+                self.client = self.auth_module.client_from_login_flow(**filtered_login_kwargs)
 
     def fetch_and_update_gamma_exposure(self):
         eastern = pytz.timezone('US/Eastern')
@@ -39,7 +165,22 @@ class GammaExposureScheduler:
 
         try:
             if self.client:
-                r = self.client.get_option_chain(symbol='$SPX.X', contract_type=self.client.Options.ContractType.ALL, from_date=use_date, to_date=use_date, strike_count=50)
+                options_source = getattr(self.client_module, "Options", None) or getattr(self.client, "Options", None)
+                contract_type_all = getattr(options_source, "ContractType", None) if options_source else None
+                if contract_type_all is not None:
+                    contract_type_all = getattr(contract_type_all, "ALL", contract_type_all)
+
+                kwargs = {
+                    "symbol": self.option_symbol,
+                    "from_date": use_date,
+                    "to_date": use_date,
+                    "strike_count": self.strike_count,
+                }
+
+                if contract_type_all is not None:
+                    kwargs["contract_type"] = contract_type_all
+
+                r = self.client.get_option_chain(**kwargs)
                 if r.status_code == 200:
                     data = r.json()
                     total_gamma_exposure, self.current_gamma_exposure, self.change_in_gamma_per_strike, largest_changes, spot_price = calculate_gamma_exposure(data, self.previous_gamma_exposure)
@@ -87,7 +228,7 @@ class GammaExposureScheduler:
             else:
                 print("Outside trading hours. Waiting to resume...")
 
-            time_module.sleep(4) #sleep until time run API request again
+            time_module.sleep(4)  # Sleep until time to run API request again
 
 scheduler = GammaExposureScheduler()
 scheduler.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ selenium==4.18.1
 six==1.16.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
+schwab-py==1.0.0
 tda-api==1.6.0
 trio==0.24.0
 trio-websocket==0.11.1


### PR DESCRIPTION
## Summary
- add a broker configuration loader that can authenticate with either Schwab or TD Ameritrade credentials
- document the new broker selection workflow and include the Schwab client dependency
- refactor gamma exposure calculations to use typed helpers and resilient data handling

## Testing
- python -m compileall main.py gamma_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68e45cecb918832c922d259070058c0e