### PR TITLE
Preserve timestamps for gamma change annotations

### DIFF
--- a/gamma_analysis.py
+++ b/gamma_analysis.py
@@ -8,7 +8,7 @@ GammaCalculationResult = Tuple[
     float,
     Dict[float, float],
     Dict[float, float],
-    List[Tuple[float, float, str]],
+    List[Tuple[float, float, datetime.datetime]],
     float,
 ]
 
@@ -74,7 +74,7 @@ def calculate_gamma_exposure(
         (
             strike,
             change,
-            time_of_change_per_strike[strike].strftime("%Y-%m-%d %H:%M:%S"),
+            time_of_change_per_strike[strike],
         )
         for strike, change in largest_changes_with_time
     ]


### PR DESCRIPTION
## Summary
- keep datetime objects in largest gamma change records returned from the analysis module
- track gamma change markers in a bounded deque of timestamped strike data
- plot each gamma change marker at its recorded timestamp for synchronized scatter points

## Testing
- python -m compileall gamma_analysis.py plotter.py

------
https://chatgpt.com/codex/tasks/task_e_68e48933d18c832c85cc800440c4dd1c