### PR TITLE
Sort strike keys before plotting gamma charts

### DIFF
--- a/plotter.py
+++ b/plotter.py
@@ -52,7 +52,10 @@ class RealTimeGammaPlotter:
     def update_plot_gamma(self, current_gamma_exposure):
         self.init_plots()
 
-        strikes = list(current_gamma_exposure.keys())
+        strikes = sorted(
+            current_gamma_exposure.keys(),
+            key=lambda strike: float(strike)
+        )
         gamma_exposures = [current_gamma_exposure[strike] for strike in strikes]
         strikes_str = [str(strike) for strike in strikes]
 
@@ -61,7 +64,10 @@ class RealTimeGammaPlotter:
         self.ax[0].legend()
 
     def update_plot_change_in_gamma(self, change_in_gamma_per_strike, largest_changes):
-        strikes = list(change_in_gamma_per_strike.keys())
+        strikes = sorted(
+            change_in_gamma_per_strike.keys(),
+            key=lambda strike: float(strike)
+        )
         changes_in_gamma = [change_in_gamma_per_strike[strike] for strike in strikes]
         strikes_str = [str(strike) for strike in strikes]
 


### PR DESCRIPTION
## Summary
- sort per-strike gamma and change-in-gamma data by numeric strike before plotting
- keep tick labels aligned with sorted order so both charts share a consistent axis

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e48934911c832c99f7142dacc48370